### PR TITLE
Sleep, time function fix for macOS, and .DS_Store ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ install/
 out/
 original/
 **/__pycache__/
+.cache/
 
 test.exe
 original.zip

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ original/
 test.exe
 original.zip
 original.rar
+src/.DS_Store

--- a/src/vibrant/thread.h
+++ b/src/vibrant/thread.h
@@ -2,7 +2,6 @@
 #define THREAD_H
 
 #include "config.h"
-#include <pthread_time.h>
 
 #if ORIGINAL_COMPILER_GCC || ORIGINAL_COMPILER_CLANG
 #include "pthread.h"

--- a/src/vibrant/zeit.h
+++ b/src/vibrant/zeit.h
@@ -1676,14 +1676,14 @@ original::time::UTCTime::localZonedOffset() {
 #if ORIGINAL_PLATFORM_WINDOWS
     localtime_s(&local_tm, &t);
 #else
-    localtime_r((const time_t*)&t, &local_tm);
+    localtime_r(const_cast<const time_t*>(&t), &local_tm);
 #endif
 
     tm utc_tm{};
 #if ORIGINAL_PLATFORM_WINDOWS
     gmtime_s(&utc_tm, &t);
 #else
-    gmtime_r((const time_t*)&t, &utc_tm);
+    gmtime_r(const_cast<const time_t*>(&t), &utc_tm);
 #endif
 
     offset_seconds = static_cast<integer>(difftime(mktime(&local_tm), mktime(&utc_tm)));

--- a/src/vibrant/zeit.h
+++ b/src/vibrant/zeit.h
@@ -1676,14 +1676,14 @@ original::time::UTCTime::localZonedOffset() {
 #if ORIGINAL_PLATFORM_WINDOWS
     localtime_s(&local_tm, &t);
 #else
-    localtime_r(const_cast<const time_t*>(&t), &local_tm);
+    localtime_r(reinterpret_cast<const time_t*>(&t), &local_tm);
 #endif
 
     tm utc_tm{};
 #if ORIGINAL_PLATFORM_WINDOWS
     gmtime_s(&utc_tm, &t);
 #else
-    gmtime_r(const_cast<const time_t*>(&t), &utc_tm);
+    gmtime_r(reinterpret_cast<const time_t*>(&t), &utc_tm);
 #endif
 
     offset_seconds = static_cast<integer>(difftime(mktime(&local_tm), mktime(&utc_tm)));

--- a/src/vibrant/zeit.h
+++ b/src/vibrant/zeit.h
@@ -1676,14 +1676,14 @@ original::time::UTCTime::localZonedOffset() {
 #if ORIGINAL_PLATFORM_WINDOWS
     localtime_s(&local_tm, &t);
 #else
-    localtime_r(&t, &local_tm);
+    localtime_r((const time_t*)&t, &local_tm);
 #endif
 
     tm utc_tm{};
 #if ORIGINAL_PLATFORM_WINDOWS
     gmtime_s(&utc_tm, &t);
 #else
-    gmtime_r(&t, &utc_tm);
+    gmtime_r((const time_t*)&t, &utc_tm);
 #endif
 
     offset_seconds = static_cast<integer>(difftime(mktime(&local_tm), mktime(&utc_tm)));


### PR DESCRIPTION
Use `nanosleep` on macOS for thread sleep

Cast `time_t*` for `localtime_r` and `gmtime_r` to avoid warnings/errors.

Added `.DS_Store` to prevent committing macOS metadata files.